### PR TITLE
Update Android SDK Versions for Android 30.

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 30
     defaultConfig {
         applicationId "com.gae.scaffolder.plugin"
-        minSdkVersion 19
-        targetSdkVersion 28
+        minSdkVersion 22
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/android/lib/build.gradle
+++ b/android/lib/build.gradle
@@ -6,7 +6,7 @@ if(hasBuildExtras) {
 }
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 30
 
     /** Reference:
      *  https://developer.android.com/studio/build/gradle-tips.html#change-default-source-set-configurations
@@ -24,8 +24,8 @@ android {
 
 
     defaultConfig {
-        minSdkVersion 19
-        targetSdkVersion 28
+        minSdkVersion 22
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
 

--- a/cordova-plugin-fcm-with-dependecy-updated.podspec
+++ b/cordova-plugin-fcm-with-dependecy-updated.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name         = "hrs-cordova-plugin-fcm-with-dependecy-updated"
-  spec.version      = "6.4.4"
+  spec.version      = "6.4.5"
   spec.summary      = "Google FCM Push Notifications Cordova Plugin"
 
   # This description is used to generate tags and improve search results.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "6.4.4",
+  "version": "6.4.5",
   "name": "hrs-cordova-plugin-fcm-with-dependecy-updated",
   "cordova_name": "HRS Cordova FCM Push Plugin",
   "description": "Google Firebase Cloud Messaging Cordova Push Plugin fork with dependecy updated",

--- a/plugin.xml
+++ b/plugin.xml
@@ -17,7 +17,7 @@
   specific language governing permissions and limitations
   under the License.
 -->
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="hrs-cordova-plugin-fcm-with-dependecy-updated" version="6.4.4">
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="hrs-cordova-plugin-fcm-with-dependecy-updated" version="6.4.5">
 	<name>Cordova FCM Push Plugin</name>
 	<description>Google Firebase Cloud Messaging Cordova Push Plugin fork with dependecy updated</description>
 	<license>MIT</license>

--- a/src/ios/AppDelegate+FCMPlugin.m
+++ b/src/ios/AppDelegate+FCMPlugin.m
@@ -187,7 +187,7 @@ fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
 }
 // [END message_handling]
 
-- (void)messaging:(nonnull FIRMessaging *)messaging didReceiveRegistrationToken:(nonnull NSString *)deviceToken {
+- (void)messaging:(nonnull FIRMessaging *)messaging didReceiveRegistrationToken:(NSString *)deviceToken {
     NSLog(@"Device FCM Token: %@", deviceToken);
     // Notify about received token.
     NSDictionary *dataDict = [NSDictionary dictionaryWithObjectsAndKeys: @"deviceToken", @"token", nil];


### PR DESCRIPTION
The min and target SDK versiions in this plugin are overriding the versionings from our HRS app config.xml files. Updating them here so they match our angular-monorepo versioning.

Also added a fix for a nonnull error we get every time we build iOS.