### PR TITLE
JIR-7464 Fixed crash observed for android 12

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
-def FCM_VERSION = System.getenv("FCM_VERSION") ?: '19.0.0'
+def FCM_VERSION = System.getenv("FCM_VERSION") ?: '23.0.0'
 def GRADLE_TOOLS_VERSION = System.getenv("GRADLE_TOOLS_VERSION") ?: '3.5.3'
 def GOOGLE_SERVICES_VERSION = System.getenv("GOOGLE_SERVICES_VERSION") ?: '4.3.3'
 def SUPPORT_LIBRARY_VERSION = System.getenv("SUPPORT_LIBRARY_VERSION") ?: '28.0.0'

--- a/plugin.xml
+++ b/plugin.xml
@@ -34,7 +34,7 @@
 
 	<!-- ANDROID CONFIGURATION -->
 	<platform name="android">
-		<preference name="FCM_VERSION" default="19.0.0" />
+		<preference name="FCM_VERSION" default="23.0.0" />
 		<preference name="GRADLE_TOOLS_VERSION" default="3.5.3" />
 		<preference name="GOOGLE_SERVICES_VERSION" default="4.3.3" />
 		<preference name="SUPPORT_LIBRARY_VERSION" default="28.0.0" />

--- a/src/android/FCMPlugin.gradle
+++ b/src/android/FCMPlugin.gradle
@@ -58,6 +58,7 @@ dependencies {
     } else {
         compile "com.google.firebase:firebase-messaging:${FCM_VERSION}"
     }
+    implementation 'com.google.firebase:firebase-iid:21.1.0'
 }
 // apply plugin: 'com.google.gms.google-services'
 // class must be used instead of id(string) to be able to apply plugin from non-root gradle file


### PR DESCRIPTION
For android 12 devices we observed a crash 

```
> E/AndroidRuntime: FATAL EXCEPTION: Firebase-MyFirebaseMessagingService
>   Process: com.hrs.patient, PID: 12335
>   java.lang.IllegalArgumentException: com.hrs.patient: Targeting S+ (version 31 and above) requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent.
>   Strongly consider using FLAG_IMMUTABLE, only use FLAG_MUTABLE if some functionality depends on the PendingIntent being mutable, e.g. if it needs to be used with inline replies or bubbles.
>     at android.app.PendingIntent.checkFlags(PendingIntent.java:382)
>     at android.app.PendingIntent.getActivityAsUser(PendingIntent.java:465)
>     at android.app.PendingIntent.getActivity(PendingIntent.java:451)
>     at android.app.PendingIntent.getActivity(PendingIntent.java:415)
>     at com.google.firebase.messaging.zzb.zzf(Unknown Source:68)
>     at com.google.firebase.messaging.zzc.zzas(Unknown Source:34)
>    at com.google.firebase.messaging.FirebaseMessagingService.zzd(Unknown Source:59)
>     at com.google.firebase.iid.zzb.run(Unknown Source:2)
>     at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
>     at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
>     at com.google.android.gms.common.util.concurrent.zza.run(Unknown Source:6)
>     at java.lang.Thread.run(Thread.java:920)

```

**Solution:**

- As seen in the above crash logs, the issue is not occurring from the plugin but from the firebase SDK to which the plugin is referring to
- The currently referred version of firebase messaging lib is 19.0.0 (FCM_VERSION)
- As per firebase documentation and research around this, Android 12 crash issue has been fixed in their version 23.0.0
- When I updated the firebase  version to 23.0.0, we found that there have been breaking changes 
- As per the release documentation, with the latest changes, either we have to completely migrate the implementation to use new FCM’s token based APIs, OR we can add a direct dependency on the firebase-iid library to your build.gradle file.
- Migration is a major change so we tried implementing the second suggested approach of adding the dependency
- This works and issue is no more reproducible.